### PR TITLE
Allow newer puppetlabs/apt

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -18,7 +18,7 @@
     },
     {
       "name": "puppetlabs/apt",
-      "version_requirement": ">= 2.0.0 < 8.0.0"
+      "version_requirement": ">= 2.0.0 < 10.0.0"
     },
     {
       "name": "puppet/selinux",


### PR DESCRIPTION
Only our gluster and wazuh modules are preventing us from using a newer version of the puppetlabs/apt module.